### PR TITLE
Fix font loading regression on atom >=1.49.0

### DIFF
--- a/lib/terminal-view.js
+++ b/lib/terminal-view.js
@@ -14,6 +14,12 @@ export default class TerminalView {
     this.disposables = new CompositeDisposable();
     this.session = session;
 
+    this.disposables.add(atom.packages.onDidActivateInitialPackages(() => {
+      // trigger a resize event so that the terminal loads without needing an
+      // additional resize
+      this.didResize();
+    }));
+
     // Load the Fit Addon
     this.fitAddon = new FitAddon();
     this.session.xterm.loadAddon(this.fitAddon);
@@ -104,6 +110,10 @@ export default class TerminalView {
   // the pseudoterminal (pty) to remain consistent.
   //
   didResize() {
+    // do not open the terminal unless initial packages have been activated
+    if (!atom.packages.initialPackagesActivated) {
+      return;
+    }
     if (!this.session.xterm.element) {
       this.openTerminal();
     }


### PR DESCRIPTION
This should fix #5. The terminal view rendering will be deferred after initial atom packages have loaded.