### PR TITLE
Fixed double new lines being input on wsl, added options for width, height, and clearOnInsert

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -2,148 +2,175 @@
 
 export default {
 
-  defaultLocation: {
-    title: 'Default Location',
-    description: 'Where to open new terminals. They will open in the bottom pane, by default.',
-    type: 'string',
-    default: 'bottom',
-    enum: [
-      { value: 'bottom', description: 'Bottom' },
-      { value: 'center', description: 'Center' },
-      { value: 'left', description: 'Left' },
-      { value: 'right', description: 'Right' }
-    ]
-  },
+	terminalDirectory: {
+		title: 'Terminal Directory',
+		description: 'What directory to open new terminals in. If you choose "Current File Folder" or "Project Folder" and the script fails to retrieve information about the linked file, it will fall back to the first project\'s folder (the topmost project-folder in tree-view). If there is no project-folder open it will instead fall back to the user\'s home directory',
+		type: 'string',
+		order: 1,
+		default: 'current-file',
+		enum: [
+			{ value: 'current-file', description: 'Current File Folder' },
+			{ value: 'project-folder', description: 'Project Folder' },
+			{ value: 'home', description: 'Home' }
+		]
+	},
 
-  fontFamily: {
-    title: 'Font Family',
-    description: 'The name of the font family used for terminal text. By default, this matches the editor font family.',
-    type: 'string',
-    default: ''
-  },
+	customTexts: {
+		type: 'object',
+		description: '$F is replaced by file name, $D is replaced by file directory, $$ is replaced by $ and $P is replaced by absolute path to file (directory followed by filename). Use $P if you want to be able to always get the correct file, regardless of what directory you are currently located at inside the terminal.',
+		order: 2,
+		properties: {
+			focusOnInsert: {
+				title: 'Focus On Insert',
+				description: 'When enabled, the terminal will be focused when using the insert command.',
+				type: 'boolean',
+				order: 1,
+				default: true
+			},
+			clearOnInsert: {
+				title: 'Clear On Insert',
+				description: 'When enabled, the terminal will be cleared when using the insert command.',
+				type: 'boolean',
+				order: 2,
+				default: false
+			},
+			runInsertedText: {
+				title: 'Run Inserted Text',
+				description: 'Run text inserted via \'iv-terminal:insert-custom-text\' as a command. **This will append an end-of-line character to input.**',
+				type: 'boolean',
+				order: 3,
+				default: true
+			},
+			saveOnInsert: {
+				title: 'Save On Insert',
+				description: 'When enabled, the active file will be saved when using the insert command.',
+				type: 'boolean',
+				order: 4,
+				default: true
+			},
+			customText1: {
+				title: 'Custom text 1',
+				description: 'Text to paste when calling iv-terminal:insert-custom-text-1',
+				type: 'string',
+				default: ''
+			},
+			customText2: {
+				title: 'Custom text 2',
+				description: 'Text to paste when calling iv-terminal:insert-custom-text-2',
+				type: 'string',
+				default: ''
+			},
+			customText3: {
+				title: 'Custom text 3',
+				description: 'Text to paste when calling iv-terminal:insert-custom-text-3',
+				type: 'string',
+				default: ''
+			},
+			customText4: {
+				title: 'Custom text 4',
+				description: 'Text to paste when calling iv-terminal:insert-custom-text-4',
+				type: 'string',
+				default: ''
+			},
+			customText5: {
+				title: 'Custom text 5',
+				description: 'Text to paste when calling iv-terminal:insert-custom-text-5',
+				type: 'string',
+				default: ''
+			},
+			customText6: {
+				title: 'Custom text 6',
+				description: 'Text to paste when calling iv-terminal:insert-custom-text-6',
+				type: 'string',
+				default: ''
+			}
+		}
+	},
 
-  matchTheme: {
-    title: 'Match Theme',
-    description: 'When enabled, the look of the terminal will match the currently configured Atom theme.',
-    type: 'boolean',
-    default: true
-  },
+	defaultLocation: {
+		title: 'Default Location',
+		description: 'Where to open new terminals. They will open in the bottom pane, by default.',
+		order: 3,
+		type: 'string',
+		default: 'bottom',
+		enum: [
+			{ value: 'bottom', description: 'Bottom' },
+			{ value: 'center', description: 'Center' },
+			{ value: 'left', description: 'Left' },
+			{ value: 'right', description: 'Right' }
+		]
+	},
 
-  shellSettings: {
-    type: 'object',
-    properties: {
+	width: {
+		title: 'Width',
+		description: 'The default width of the terminal, used with a location of left or right.',
+		order: 4,
+		type: 'integer',
+		default: 500
+	},
 
-      sanitizeEnvironment: {
-        title: 'Sanitized Environment Variables',
-        description: 'Specify variables to remove from the environment in the terminal session. For example, the default behavior is to unset `NODE_ENV`, since Atom sets this to "production" on launch and may not be what you want when developing a Node application.',
-        type: 'array',
-        default: [ 'NODE_ENV' ]
-      },
+	height: {
+		title: 'Height',
+		description: 'The default height of the terminal, used with a location of bottom.',
+		order: 5,
+		type: 'integer',
+		default: 300
+	},
 
-      shellPath: {
-        title: 'Shell Path',
-        description: 'Path to your shell application. Uses the $SHELL environment variable by default on *NIX and %COMSPEC% on Windows.',
-        type: 'string',
-        default: (() => {
-          if (process.platform === 'win32') {
-            return process.env.COMSPEC || 'cmd.exe';
-          } else {
-            return process.env.SHELL || '/bin/bash';
-          }
-        })()
-      },
+	fontFamily: {
+		title: 'Font Family',
+		description: 'The name of the font family used for terminal text. By default, this matches the editor font family.',
+		order: 6,
+		type: 'string',
+		default: ''
+	},
 
-      shellArgs: {
-        title: 'Shell Arguments',
-        description: 'Arguments to send to the shell application on launch. Sends "--login" by default on *NIX and nothing on Windows.',
-        type: 'string',
-        default: (() => {
-          if (process.platform !== 'win32' && process.env.SHELL === '/bin/bash') {
-            return '--login';
-          } else {
-            return '';
-          }
-        })()
-      }
+	matchTheme: {
+		title: 'Match Theme',
+		description: 'When enabled, the look of the terminal will match the currently configured Atom theme.',
+		order: 7,
+		type: 'boolean',
+		default: true
+	},
 
-    }
-  },
+	shellSettings: {
+		type: 'object',
+		properties: {
 
-  terminalDirectory: {
-    title: 'Terminal Directory',
-    description: 'What directory to open new terminals in. If you choose "Current File Folder" or "Project Folder" and the script fails to retrieve information about the linked file, it will fall back to the first project\'s folder (the topmost project-folder in tree-view). If there is no project-folder open it will instead fall back to the user\'s home directory',
-    type: 'string',
-    order: 1,
-    default: 'current-file',
-    enum: [
-      { value: 'current-file', description: 'Current File Folder' },
-      { value: 'project-folder', description: 'Project Folder' },
-      { value: 'home', description: 'Home' }
-    ]
-  },
+			sanitizeEnvironment: {
+				title: 'Sanitized Environment Variables',
+				description: 'Specify variables to remove from the environment in the terminal session. For example, the default behavior is to unset `NODE_ENV`, since Atom sets this to "production" on launch and may not be what you want when developing a Node application.',
+				type: 'array',
+				default: [ 'NODE_ENV' ]
+			},
 
-  customTexts: {
-    type: 'object',
-    description: '$F is replaced by file name, $D is replaced by file directory, $$ is replaced by $ and $P is replaced by absolute path to file (directory followed by filename). Use $P if you want to be able to always get the correct file, regardless of what directory you are currently located at inside the terminal.',
-    order: 2,
-    properties: {
-      focusOnInsert: {
-        title: 'Focus On Insert',
-        description: 'When enabled, the terminal will be focused when using the insert command.',
-        type: 'boolean',
-        order: 1,
-        default: true
-      },
-      runInsertedText: {
-        title: 'Run Inserted Text',
-        description: 'Run text inserted via \'iv-terminal:insert-custom-text\' as a command. **This will append an end-of-line character to input.**',
-        type: 'boolean',
-        order: 2,
-        default: true
-      },
-      saveOnInsert: {
-        title: 'Save On Insert',
-        description: 'When enabled, the active file will be saved when using the insert command.',
-        type: 'boolean',
-        order: 3,
-        default: true
-      },
-      customText1: {
-        title: 'Custom text 1',
-        description: 'Text to paste when calling iv-terminal:insert-custom-text-1',
-        type: 'string',
-        default: ''
-      },
-      customText2: {
-        title: 'Custom text 2',
-        description: 'Text to paste when calling iv-terminal:insert-custom-text-2',
-        type: 'string',
-        default: ''
-      },
-      customText3: {
-        title: 'Custom text 3',
-        description: 'Text to paste when calling iv-terminal:insert-custom-text-3',
-        type: 'string',
-        default: ''
-      },
-      customText4: {
-        title: 'Custom text 4',
-        description: 'Text to paste when calling iv-terminal:insert-custom-text-4',
-        type: 'string',
-        default: ''
-      },
-      customText5: {
-        title: 'Custom text 5',
-        description: 'Text to paste when calling iv-terminal:insert-custom-text-5',
-        type: 'string',
-        default: ''
-      },
-      customText6: {
-        title: 'Custom text 6',
-        description: 'Text to paste when calling iv-terminal:insert-custom-text-6',
-        type: 'string',
-        default: ''
-      }
-    }
-  }
+			shellPath: {
+				title: 'Shell Path',
+				description: 'Path to your shell application. Uses the $SHELL environment variable by default on *NIX and %COMSPEC% on Windows.',
+				type: 'string',
+				default: (() => {
+					if (process.platform === 'win32') {
+						return process.env.COMSPEC || 'cmd.exe';
+					} else {
+						return process.env.SHELL || '/bin/bash';
+					}
+				})()
+			},
+
+			shellArgs: {
+				title: 'Shell Arguments',
+				description: 'Arguments to send to the shell application on launch. Sends "--login" by default on *NIX and nothing on Windows.',
+				type: 'string',
+				default: (() => {
+					if (process.platform !== 'win32' && process.env.SHELL === '/bin/bash') {
+						return '--login';
+					} else {
+						return '';
+					}
+				})()
+			}
+
+		}
+	},
+
 };

--- a/lib/main.js
+++ b/lib/main.js
@@ -48,6 +48,10 @@ function handleCustomInsert(customText) {
       terminal = activeTerminalSessions[filePath];
   }
 
+  if (atom.config.get('iv-terminal.customTexts.clearOnInsert')) {
+	  terminal.clear();
+  }
+
   terminal.insertCustomText(customText);
 }
 

--- a/lib/terminal-session.js
+++ b/lib/terminal-session.js
@@ -247,6 +247,14 @@ export default class TerminalSession {
     return atom.config.get('iv-terminal.defaultLocation');
   }
 
+  getPreferredWidth() {
+    return atom.config.get('iv-terminal.width');
+  }
+
+  getPreferredHeight() {
+    return atom.config.get('iv-terminal.height');
+  }
+
   getIconName() {
     return 'terminal';
   }

--- a/lib/terminal-session.js
+++ b/lib/terminal-session.js
@@ -96,8 +96,12 @@ export default class TerminalSession {
     newLine = "\n";
     slash = "/";
     if (process.platform === 'win32') {
-      newLine = "\r" + newLine;
-      slash = "\\";
+      shellPathParts = this.shellPath.split('\\');
+      shellName = shellPathParts[shellPathParts.length-1];
+      if (shellName != 'wsl.exe') {
+        newLine = "\r" + newLine;
+        slash = "\\";
+      }
     }
     if (!atom.config.get('iv-terminal.customTexts.runInsertedText')) {
       newLine = "";


### PR DESCRIPTION
While doing the command insert-custom-text on the Windows Subsystem for Linux, it would insert an extra new line.  This new change fixes it. The behavior is still as expected for cmd.exe.